### PR TITLE
fix: upgrade brakes strategy

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -5,39 +5,44 @@ it("splits a string by spaces", () =>
   expect(splitg(`abc def g`)).toEqual(["abc", "def", "g"]));
 it("splits a string by a custom separator", () =>
   expect(splitg(`abc~def~g`, "~")).toEqual(["abc", "def", "g"]));
-it("splits a string preserving curly braces", () =>
-  expect(splitg(`{abc def} g`)).toEqual(["{abc def}", "g"]));
-it("splits a string preserving parentheses", () =>
-  expect(splitg(`(abc def) g`)).toEqual(["(abc def)", "g"]));
-it("splits a string preserving square brackets", () =>
-  expect(splitg(`[abc def] g`)).toEqual(["[abc def]", "g"]));
-it("splits a string preserving nested square brackets", () =>
-  expect(splitg(`a [[abc [def]]] g`)).toEqual(["a", "[[abc [def]]]", "g"]));
 it("splits a string preserving backslashes", () =>
   expect(splitg(`abc\\ def g`)).toEqual(["abc\\ def", "g"]));
-it("splits a string preserving angle brackets (default)", () =>
-  expect(splitg(`<abc def> g`)).toEqual(["<abc", "def>", "g"]));
-it("splits a string preserving angle brackets (custom)", () =>
-  expect(splitg(`<abc def> g`, undefined, { brackets: [["<", ">"]] })).toEqual([
-    "<abc def>",
-    "g",
-  ])),
-  it("splits a string with trailing spaces", () =>
-    expect(splitg(`abc def g  `)).toEqual(["abc", "def", "g", "", ""]));
-it("splits a string with a json object", () =>
-  expect(
-    splitg(`this is a json { "name": "ok" } with a property name`),
-  ).toEqual([
-    `this`,
-    `is`,
-    `a`,
-    `json`,
-    `{ "name": "ok" }`,
-    `with`,
-    `a`,
-    `property`,
-    `name`,
-  ]));
+it("splits a string with trailing spaces", () =>
+  expect(splitg(`abc def g  `)).toEqual(["abc", "def", "g", "", ""]));
+
+describe("preserving brackets", () => {
+  it("splits a string preserving curly braces", () =>
+    expect(splitg(`{abc def} g`)).toEqual(["{abc def}", "g"]));
+  it("splits a string preserving parentheses", () =>
+    expect(splitg(`(abc def) g`)).toEqual(["(abc def)", "g"]));
+  it("splits a string preserving square brackets", () =>
+    expect(splitg(`[abc def] g`)).toEqual(["[abc def]", "g"]));
+  it("splits a string preserving nested square brackets", () =>
+    expect(splitg(`a [[abc [def]]] g`)).toEqual(["a", "[[abc [def]]]", "g"]));
+  it("splits a string preserving angle brackets (default)", () =>
+    expect(splitg(`<abc def> g`)).toEqual(["<abc", "def>", "g"]));
+  it("splits a string preserving angle brackets (custom)", () =>
+    expect(
+      splitg(`<abc def> g`, undefined, { brackets: [["<", ">"]] }),
+    ).toEqual(["<abc def>", "g"])),
+    it("splits a string with a json object", () =>
+      expect(
+        splitg(`this is a json { "name": "ok" } with a property name`),
+      ).toEqual([
+        `this`,
+        `is`,
+        `a`,
+        `json`,
+        `{ "name": "ok" }`,
+        `with`,
+        `a`,
+        `property`,
+        `name`,
+      ]));
+
+  it("splits a string preserving mixed brackets", () =>
+    expect(splitg(`a [ ( ] ) ] b`)).toEqual([`a`, `[ ( ]`, `)`, `]`, `b`]));
+});
 
 describe("parseSplitgOptions", () => {
   it("should parse a string splitter", () =>


### PR DESCRIPTION
- **tests: upgrade tests caces**
- **fix: change brakes delimiter strategy**

Add new test case:

Before:

```ts
splitg(`a [ ( ] ) ] b`) // => [`a`, `[ ( ] ) ]`, `b`]
```

After:

```ts
splitg(`a [ ( ] ) ] b`) // => [`a`, `[ ( ]`, `)`, `]`, `b`]
```